### PR TITLE
Tweak CSP to allow loading images from external sites

### DIFF
--- a/roles/webserver/templates/edgebuilder.conf.j2
+++ b/roles/webserver/templates/edgebuilder.conf.j2
@@ -2,7 +2,7 @@ server_tokens off;
 add_header X-Frame-Options SAMEORIGIN;
 add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com https://assets.zendesk.com https://connect.facebook.net; img-src 'self' https://ssl.google-analytics.com https://s-static.ak.facebook.com https://assets.zendesk.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://assets.zendesk.com; font-src 'self' https://themes.googleusercontent.com; frame-src https://assets.zendesk.com https://www.facebook.com https://s-static.ak.facebook.com https://tautt.zendesk.com; object-src 'none'";
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com https://assets.zendesk.com https://connect.facebook.net; img-src *; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://assets.zendesk.com; font-src 'self' https://themes.googleusercontent.com; frame-src https://assets.zendesk.com https://www.facebook.com https://s-static.ak.facebook.com https://tautt.zendesk.com; object-src 'none'";
 
 upstream webapp {
   server 127.0.0.1:{{ edgebuilder_primary_port }};


### PR DESCRIPTION
Right now the Content Security Policy for `img-src` only allows images to be loaded from the same origin as the site. Specifying a wildcard to allow images to be loaded from any site, for profile pic URLs in character sheets. 

Most of the CSP settings here look like copypasta, as I don't see any resources being loaded from Facebook, Google Analytics, Zendesk, etc.
